### PR TITLE
Change expected value to make CI fail

### DIFF
--- a/test_func.py
+++ b/test_func.py
@@ -6,7 +6,7 @@ def test_sinusoidal_PWM_frequency():
     
 
 def test_adc_frequency_calc():
-    assert adc_frequency_calc(0,1) == 0
+    assert adc_frequency_calc(0,1) == 1
     
     
     

--- a/test_func.py
+++ b/test_func.py
@@ -6,7 +6,7 @@ def test_sinusoidal_PWM_frequency():
     
 
 def test_adc_frequency_calc():
-    assert adc_frequency_calc(0,1) == 1
+    assert adc_frequency_calc(0,1)==1
     
     
     


### PR DESCRIPTION
# Overview

This is the evaluation for the first homework assignment.

In this PR, I do the following steps:

- Change the expected value of a test to make sure that pytest fails
- Introduce a pep8-incompatible syntax change to test whether Stickler finds it

For some reason, Stickler did run but did not identify the pep8-incompatible change. At a quick glance, I could not identify why it is not working as expected. I suggest that in the future, you specifically add a PR making CI fail to ensure that it is working as expected.

Feel free to close this PR.

# Grade

Very good (1)

# Other comments

First, your tests only cover the "special" cases where no computation is done, but not the useful parts of your methods. In such cases, it would be useful to test for the expected/useful behavior and the other outcomes.

Second, It seems to me that non-positive values are not valid in your methods. Instead of simply returning 0, it is a better design pattern to raise an explicit error so that the users knows something unexpected or invalid is happening.

See for example the case where `pyam.IamDataFrame.timeseries()` is called on an empty dataset:
https://github.com/IAMconsortium/pyam/blob/516da604443579fd4942e5f3c6c1413e1feec5d4/pyam/core.py#L789

and the corresponding test:
https://github.com/IAMconsortium/pyam/blob/516da604443579fd4942e5f3c6c1413e1feec5d4/tests/test_core.py#L399